### PR TITLE
Update sim_state.py module and class docstrings

### DIFF
--- a/src/sim_state.py
+++ b/src/sim_state.py
@@ -1,43 +1,35 @@
 # -*- coding: utf-8 -*-
 """
 sim_state.py
+============
 
-This module defines a unified class for storing the state of advection,
-compressible hydrodynamics (HD), special-relativistic hydrodynamics (rHD),
-magnetohydrodynamics (MHD), special-relativistic magnetohydrodynamics (rMHD),
-and thermal diffusion on a 2D computational grid.
-It is designed for frameworks that compare numerical methods and solvers across
-different physics modules.
+Unified state container for all Piastra simulation modes on a 2D grid.
 
-The SimState (simulated state) class allocates arrays according to the selected mode:
+The SimState class allocates arrays according to the selected mode:
 
-- 'adv'  : scalar field(s) for linear advection, plus optional advection
-  velocities.
-- 'HD'   : compressible hydrodynamics with primitive and conservative
-  variables, plus optional source terms.
-- 'rHD'  : special-relativistic hydrodynamics; same arrays as HD.
-- 'MHD'  : HD arrays plus magnetic fields, staggered magnetic fields,
-  divergence-cleaning arrays, and conservative magnetic fluxes.
-- 'rMHD' : same arrays as MHD (SR conservative/primitive + B-fields).
-- 'diff' : scalar temperature field T and thermal diffusivity kappa.
+- 'adv'  : scalar density field plus constant advection velocities.
+- 'HD'   : compressible hydrodynamics — primitive variables, conservative
+  variables, and external source terms.
+- 'rHD'  : special-relativistic hydrodynamics — same layout as HD.
+- 'MHD'  : HD arrays plus cell-centred (bfi) and face-centred (fb)
+  magnetic fields, conservative magnetic fluxes (bcon), and a
+  divergence monitor (divB).
+- 'rMHD' : same layout as MHD (SRMHD conservative/primitive + B-fields).
+- 'diff' : scalar temperature field T and scalar thermal diffusivity kappa.
 
-Primitive variables include ghost cells to simplify boundary condition
-handling, while conservative variables and source terms are defined only
-in the interior physical domain. Magnetic fields are allocated only when
-MHD mode is enabled.
-
-This module does not implement solvers; it only provides storage for state
-variables. External solver routines can access the arrays consistently
-regardless of the mode.
+Ghost cells are included only for primitive variables (and magnetic
+fields), to simplify boundary condition handling.  Conservative variables
+and source terms are interior-only arrays of shape ``(Nx1, Nx2)``.
 
 Notes
 -----
-- Ghost cells exist only for primitive variables.
-- For 'adv' mode, only the scalar field and advection velocities are
-  allocated.
-- HD and MHD arrays are fully allocated for solver testing and comparison.
-- MHD-specific arrays include both cell-centered (bfi) and staggered (fb)
-  fields, as well as divergence-cleaning (divB).
+- Magnetic field arrays (bfi*, fb*, bcon*, divB) are allocated for
+  modes 'MHD' and 'rMHD'.  They are also allocated in 'HD' mode to
+  allow unified array access in solver dispatch loops, but are not
+  used by the HD physics routines.
+- This module does not implement any solvers; it is pure storage.
+  External solver routines access the arrays consistently regardless
+  of the mode.
 
 Author: mrkondratyev
 """
@@ -46,63 +38,69 @@ import numpy as np
 
 class SimState:
     """
-    Container for advection, compressible fluid, or MHD state variables
-    on a 2D computational grid.
+    Container for simulation state variables on a 2D computational grid.
 
-    The class allocates arrays depending on the selected mode:
+    Allocates arrays depending on ``par.mode``.
 
     Parameters
     ----------
     grid : Grid
-        Grid object providing geometry and array sizes. Must define
-        `grid.grid_shape`, `grid.Nx1`, and `grid.Nx2`.
-    par : parameters
-        Simulation parameters object with attribute `mode` that can be
-        'adv', 'HD', 'rHD', 'MHD', 'rMHD', or 'diff'. Determines which arrays are allocated.
+        Grid object providing geometry and array sizes.  Must define
+        ``grid.grid_shape``, ``grid.Nx1``, and ``grid.Nx2``.
+    par : Parameters
+        Simulation parameters.  ``par.mode`` controls which arrays are
+        allocated: 'adv', 'HD', 'rHD', 'MHD', 'rMHD', or 'diff'.
 
     Attributes
     ----------
-    # Mode flags
-    dens : ndarray
-        Scalar field for linear advection (only in 'adv' mode).
-    vel1, vel2 : float or ndarray
-        Advection velocities (float for 'adv', arrays for HD/MHD).
+    Advection mode ('adv')
+    ~~~~~~~~~~~~~~~~~~~~~~
+    dens : ndarray, shape grid.grid_shape
+        Scalar advected field (with ghost cells).
+    vel1, vel2 : float
+        Constant advection velocities in x1 and x2 directions.
 
-    # Primitive variables (including ghost cells, HD/MHD only)
+    Hydrodynamics / relativistic HD / MHD / rMHD modes
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Primitive variables (shape grid.grid_shape, include ghost cells):
+
     dens : ndarray
-        Mass density field.
+        Rest-mass (or mass) density.
     vel1, vel2, vel3 : ndarray
-        Velocity components along each coordinate direction.
+        Velocity components along x1, x2, x3.
     pres : ndarray
-        Pressure field.
-    
-    # Magnetic fields (MHD only)
-    bfi1, bfi2, bfi3 : ndarray
-        Cell-centered magnetic field components.
-    fb1, fb2 : ndarray
-        Face-centered (staggered) magnetic field components.
-    
-    # Conservative variables (interior only, HD/MHD only)
+        Thermal pressure.
+
+    Conservative variables (shape (Nx1, Nx2), interior only):
+
     mass : ndarray
-        Mass per unit volume.
+        Conserved mass density (D = rho W for relativistic modes).
     mom1, mom2, mom3 : ndarray
-        Momentum components per unit volume.
+        Conserved momentum components.
     etot : ndarray
-        Total energy per unit volume.
-    bcon1, bcon2, bcon3 : ndarray
-        Conserved magnetic fluxes (MHD only).
-
-    # Auxiliary
-    divB : ndarray
-        Divergence of magnetic field (MHD only).
+        Total energy density.
     F1, F2 : ndarray
-        User-defined source terms (HD/rHD/MHD only, e.g., gravity).
+        External force source terms (e.g., gravity).
 
-    # Diffusion (diff mode only)
-    T : ndarray
-        Temperature field.
+    Magnetic fields ('MHD', 'rMHD', and 'HD' modes):
+
+    bfi1, bfi2, bfi3 : ndarray, shape grid.grid_shape
+        Cell-centred magnetic field components (with ghost cells).
+    fb1 : ndarray, shape (Nx1+1, Nx2)
+        Face-centred B-field component normal to x1-faces (staggered).
+    fb2 : ndarray, shape (Nx1, Nx2+1)
+        Face-centred B-field component normal to x2-faces (staggered).
+    bcon1, bcon2, bcon3 : ndarray, shape (Nx1, Nx2)
+        Conservative magnetic flux densities (interior only).
+    divB : ndarray, shape (Nx1, Nx2)
+        Divergence of the magnetic field (diagnostic monitor).
+
+    Diffusion mode ('diff')
+    ~~~~~~~~~~~~~~~~~~~~~~~
+    T : ndarray, shape grid.grid_shape
+        Temperature field (with ghost cells).
     kappa : float
-        Thermal diffusivity (uniform).
+        Uniform thermal diffusivity coefficient.
     """
 
 


### PR DESCRIPTION
- Rewrite module docstring: clearer mode descriptions, note that magnetic field arrays are allocated for HD mode too (for solver dispatch uniformity), though they are unused by HD physics
- Rewrite SimState class docstring: group attributes by mode, document array shapes precisely (grid.grid_shape vs interior-only), add rMHD to all relevant sections

https://claude.ai/code/session_01P4nk7Nvqys6mXPk24BmVcC